### PR TITLE
fix(editorconfig): markdown expects spaces, not tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,5 +11,5 @@ insert_final_newline = true
 indent_style = tab
 max_line_length = 100
 
-[*.{yml,yaml}]
+[*.{yml,yaml,md}]
 indent_style = space

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wescfg",
-	"version": "0.0.17",
+	"version": "0.0.18",
 	"description": "Whyhankee's ESlint/Prettier config",
 	"main": "src/index.mjs",
 	"type": "module",

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -91,7 +91,7 @@ export const prettierConfig = {
 	tabWidth: 2,
 	overrides: [
 		{
-			files: ["*.yml", "*.yaml"],
+			files: ["*.yml", "*.yaml", "*.md"],
 			options: {
 				useTabs: false,
 			},

--- a/src/init.mjs
+++ b/src/init.mjs
@@ -61,7 +61,7 @@ insert_final_newline = true
 indent_style = tab
 max_line_length = 100
 
-[*.{yml,yaml}]
+[*.{yml,yaml,md}]
 indent_style = space
 `
 


### PR DESCRIPTION
* fix(editorconfig): markdown expects spaces, not tabs
* v0.0.18